### PR TITLE
Have JSON examples compatible with Swagger and a few other fixes

### DIFF
--- a/src/N8NPropertiesBuilder.spec.ts
+++ b/src/N8NPropertiesBuilder.spec.ts
@@ -97,6 +97,8 @@ test('query param - schema', () => {
                     description: 'List all entities',
                     routing: {
                         request: {
+                            "encoding": "json",
+                            "json": true,
                             method: 'GET',
                             url: '=/api/entities',
                         },
@@ -247,6 +249,8 @@ test('query param - content', () => {
                     "name": "List",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "GET",
                             "url": "=/api/entities"
                         }
@@ -365,6 +369,8 @@ test('query param - dot in field name', () => {
                     description: 'List all entities',
                     routing: {
                         request: {
+                            "encoding": "json",
+                            "json": true,
                             method: 'GET',
                             url: '=/api/entities',
                         },
@@ -475,6 +481,8 @@ test('path param', () => {
                     description: 'Get entity',
                     routing: {
                         request: {
+                            "encoding": "json",
+                            "json": true,
                             method: 'GET',
                             url: '=/api/entities/{{$parameter["entity"]}}',
                         },
@@ -595,6 +603,8 @@ test('request body', () => {
                     description: 'Create entity',
                     routing: {
                         request: {
+                            "encoding": "json",
+                            "json": true,
                             method: 'POST',
                             url: '=/api/entities',
                         },
@@ -742,6 +752,8 @@ test('enum schema', () => {
                     description: 'Create entity',
                     routing: {
                         request: {
+                            "encoding": "json",
+                            "json": true,
                             method: 'POST',
                             url: '=/api/entities',
                         },
@@ -753,6 +765,7 @@ test('enum schema', () => {
         },
         {
             displayName: 'Type',
+            description: undefined,
             name: 'type',
             type: 'options',
             default: 'type1',
@@ -849,6 +862,8 @@ test('body "array" param', () => {
                     "name": "Create",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "POST",
                             "url": "=/api/entities"
                         }
@@ -995,6 +1010,8 @@ test('test overrides', () => {
                     description: 'Create entity',
                     routing: {
                         request: {
+                            "encoding": "json",
+                            "json": true,
                             method: 'POST',
                             url: '=/api/entities',
                         },
@@ -1145,6 +1162,8 @@ test('multiple tags', () => {
                         "name": "List",
                         "routing": {
                             "request": {
+                                "encoding": "json",
+                                "json": true,
                                 "method": "GET",
                                 "url": "=/api/entities"
                             }
@@ -1173,6 +1192,8 @@ test('multiple tags', () => {
                         "name": "List",
                         "routing": {
                             "request": {
+                                "encoding": "json",
+                                "json": true,
                                 "method": "GET",
                                 "url": "=/api/entities"
                             }
@@ -1338,6 +1359,8 @@ test('no tags - default tag', () => {
                         "name": "List",
                         "routing": {
                             "request": {
+                                "encoding": "json",
+                                "json": true,
                                 "method": "GET",
                                 "url": "=/api/entities"
                             }

--- a/src/n8n/SchemaToINodeProperties.ts
+++ b/src/n8n/SchemaToINodeProperties.ts
@@ -102,7 +102,7 @@ export class N8NINodeProperties {
         }
         const fieldParameterKeys: Partial<INodeProperties> = {
             displayName: lodash.startCase(parameter.name),
-            name: parameter.name.replace(/\./g, "-"),
+            name: encodeURIComponent(parameter.name.replace(/\./g, "-")),
             required: parameter.required,
             description: parameter.description,
             default: parameter.example,

--- a/src/n8n/SchemaToINodeProperties.ts
+++ b/src/n8n/SchemaToINodeProperties.ts
@@ -39,9 +39,9 @@ export class N8NINodeProperties {
     }
 
     fromSchema(schema: Schema): FromSchemaNodeProperty {
-        schema = this.refResolver.resolve<OpenAPIV3.SchemaObject>(schema)
+        schema = this.refResolver.resolve<OpenAPIV3.SchemaObject>(schema);
         let type: NodePropertyTypes;
-        let defaultValue = this.schemaExample.extractExample(schema)
+        let defaultValue = this.schemaExample.extractExample(schema);
 
         let options = undefined
 
@@ -65,7 +65,7 @@ export class N8NINodeProperties {
                 break;
             case 'array':
                 let schemaAsArray = schema as any;
-                if (schemaAsArray.items && schemaAsArray.items.enum.length > 0) {
+                if (schemaAsArray.items && schemaAsArray.items.enum && schemaAsArray.items.enum.length > 0) {
                     type = 'multiOptions';
                     options = schemaAsArray.items.enum.map((value: string) => {
                         return {

--- a/src/n8n/SchemaToINodeProperties.ts
+++ b/src/n8n/SchemaToINodeProperties.ts
@@ -43,6 +43,12 @@ export class N8NINodeProperties {
         let type: NodePropertyTypes;
         let defaultValue = this.schemaExample.extractExample(schema)
 
+        let options = undefined
+
+        if (schema.allOf) {
+            schema.type = 'object';
+        }
+
         switch (schema.type) {
             case 'boolean':
                 type = 'boolean';

--- a/src/openapi/RefResolver.ts
+++ b/src/openapi/RefResolver.ts
@@ -11,20 +11,6 @@ export class RefResolver {
      */
     resolveRef<T>(schema: OpenAPIV3.ReferenceObject | T): [T, string[]?] {
         // @ts-ignore
-        if ("properties" in schema) {
-            return [schema as T, undefined];
-        }
-        // @ts-ignore
-        if ("oneOf" in schema) {
-            // @ts-ignore
-            schema = schema.oneOf[0];
-        }
-        // @ts-ignore
-        if ("anyOf" in schema) {
-            // @ts-ignore
-            schema = schema.anyOf[0];
-        }
-        // @ts-ignore
         if ('$ref' in schema) {
             const schemaResolved = this.findRef(schema['$ref']);
             // Remove $ref from schema, add all other properties

--- a/src/openapi/RefResolver.ts
+++ b/src/openapi/RefResolver.ts
@@ -11,6 +11,20 @@ export class RefResolver {
      */
     resolveRef<T>(schema: OpenAPIV3.ReferenceObject | T): [T, string[]?] {
         // @ts-ignore
+        if ("properties" in schema) {
+            return [schema as T, undefined];
+        }
+        // @ts-ignore
+        if ("oneOf" in schema) {
+            // @ts-ignore
+            schema = schema.oneOf[0];
+        }
+        // @ts-ignore
+        if ("anyOf" in schema) {
+            // @ts-ignore
+            schema = schema.anyOf[0];
+        }
+        // @ts-ignore
         if ('$ref' in schema) {
             const schemaResolved = this.findRef(schema['$ref']);
             // Remove $ref from schema, add all other properties

--- a/src/openapi/RefResolver.ts
+++ b/src/openapi/RefResolver.ts
@@ -26,16 +26,6 @@ export class RefResolver {
             schema = schema.anyOf[0]
         }
         // @ts-ignore
-        if ("allOf" in schema) {
-            // @ts-ignore
-            const results = schema.allOf.map((s) => this.resolveRef(s));
-            const schemas = results.map((r: any) => r[0]);
-            const refs = results.map((r: any) => r[1]);
-            const refsFlat = lodash.flatten<string>(refs);
-            const object = Object.assign({}, ...schemas);
-            return [object as T, refsFlat]
-        }
-        // @ts-ignore
         if ('$ref' in schema) {
             const schemaResolved = this.findRef(schema['$ref']);
             // Remove $ref from schema, add all other properties

--- a/src/openapi/RefResolver.ts
+++ b/src/openapi/RefResolver.ts
@@ -1,5 +1,4 @@
 import {OpenAPIV3} from "openapi-types";
-import * as lodash from "lodash";
 
 export class RefResolver {
     constructor(private doc: any) {
@@ -13,17 +12,17 @@ export class RefResolver {
     resolveRef<T>(schema: OpenAPIV3.ReferenceObject | T): [T, string[]?] {
         // @ts-ignore
         if ("properties" in schema) {
-            return [schema as T, undefined]
+            return [schema as T, undefined];
         }
         // @ts-ignore
         if ("oneOf" in schema) {
             // @ts-ignore
-            schema = schema.oneOf[0]
+            schema = schema.oneOf[0];
         }
         // @ts-ignore
         if ("anyOf" in schema) {
             // @ts-ignore
-            schema = schema.anyOf[0]
+            schema = schema.anyOf[0];
         }
         // @ts-ignore
         if ('$ref' in schema) {
@@ -31,13 +30,13 @@ export class RefResolver {
             // Remove $ref from schema, add all other properties
             const {$ref, ...rest} = schema;
             Object.assign(rest, schemaResolved);
-            return [rest as T, [$ref]]
+            return [rest as T, [$ref]];
         }
-        return [schema as T, undefined]
+        return [schema as T, undefined];
     }
 
     resolve<T>(schema: OpenAPIV3.ReferenceObject | T): T {
-        return this.resolveRef(schema)[0]
+        return this.resolveRef(schema)[0];
     }
 
     private findRef(ref: string): OpenAPIV3.SchemaObject {

--- a/src/openapi/SchemaExample.ts
+++ b/src/openapi/SchemaExample.ts
@@ -69,10 +69,7 @@ class SchemaExampleBuilder {
                     return []
                 case 'number':
                 case 'integer':
-                    if (schema.maximum || schema.minimum || schema.exclusiveMinimum || schema.exclusiveMaximum || schema.multipleOf) {
-                        return generateNumberWithConstraints(schema);
-                    }
-                    return 0;
+                    return generateNumberWithConstraints(schema);
                 default: // null for OpenAPI 3.1
                     return null;
             }

--- a/src/openapi/SchemaExample.ts
+++ b/src/openapi/SchemaExample.ts
@@ -4,7 +4,9 @@ import {OpenAPIV3} from "openapi-types";
 class SchemaExampleBuilder {
     private visitedRefs: Set<string> = new Set<string>();
 
-    constructor(private resolver: RefResolver) {
+    constructor(private resolver: RefResolver, refs?: Set<string>) {
+        if (refs)
+            this.visitedRefs = new Set([...refs])
     }
 
     build(schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject, guessDefault: boolean = false): any {
@@ -43,7 +45,7 @@ class SchemaExampleBuilder {
         if (schema.properties) {
             const obj: any = example ?? {};
             for (const key in schema.properties) {
-               obj[key] = this.build(schema.properties[key], true);
+                obj[key] = (new SchemaExampleBuilder(this.resolver, this.visitedRefs)).build(schema.properties[key], true);
             }
             example = obj;
         }

--- a/src/openapi/SchemaExample.ts
+++ b/src/openapi/SchemaExample.ts
@@ -7,29 +7,29 @@ class SchemaExampleBuilder {
     constructor(private resolver: RefResolver) {
     }
 
-    build(schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject): any {
-        let refs: string[] | undefined
-        [schema, refs] = this.resolver.resolveRef(schema)
+    build(schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject, guessDefault: boolean = false): any {
+        let refs: string[] | undefined;
+        [schema, refs] = this.resolver.resolveRef(schema);
 
-        let example: any = undefined
+        let example: any = undefined;
 
         if (refs) {
             // Prevent infinite recursion
             for (const ref of refs) {
                 if (this.visitedRefs.has(ref)) {
-                    return {}
+                    return {};
                 }
                 this.visitedRefs.add(ref);
             }
         }
         if ('oneOf' in schema) {
-            return this.build(schema.oneOf!![0]);
+            return this.build(schema.oneOf!![0], guessDefault);
         }
         if (schema.example !== undefined) {
             return schema.example;
         }
         if ('allOf' in schema) {
-            const examples = schema.allOf!!.map((s) => this.build(s));
+            const examples = schema.allOf!!.map((s) => this.build(s, true));
             example = Object.assign({}, ...examples);
         }
 
@@ -39,7 +39,7 @@ class SchemaExampleBuilder {
         if (schema.properties) {
             const obj: any = example ?? {};
             for (const key in schema.properties) {
-                obj[key] = this.build(schema.properties[key]);
+                obj[key] = this.build(schema.properties[key], true);
             }
             example = obj;
         }
@@ -47,25 +47,31 @@ class SchemaExampleBuilder {
             return schema.enum[0];
         }
         if ('items' in schema && schema.items) {
-            return [this.build(schema.items)];
+            if (schema.type === 'array' && schema.items && (schema.items as OpenAPIV3.SchemaObject).enum) {
+                return (schema.items as OpenAPIV3.SchemaObject).enum;
+            }
+            return [this.build(schema.items, true) ?? "string"];
         }
         if (example) {
             return example;
         }
         // In 3.1 schema.type can be an array
         let type = (schema.type && typeof schema.type !== "string") ? schema.type[0] : schema.type;
-        if (type) {
+        if (type && guessDefault) {
             switch (type) {
                 case 'boolean':
                     return true;
                 case 'string':
-                    return '';
+                    return generateString(schema);
                 case 'object':
                     return {};
                 case 'array':
-                    return [];
+                    return []
                 case 'number':
                 case 'integer':
+                    if (schema.maximum || schema.minimum || schema.exclusiveMinimum || schema.exclusiveMaximum || schema.multipleOf) {
+                        return generateNumberWithConstraints(schema);
+                    }
                     return 0;
                 default: // null for OpenAPI 3.1
                     return null;
@@ -73,6 +79,65 @@ class SchemaExampleBuilder {
         }
         return undefined;
     }
+}
+
+const generateString = (schema: OpenAPIV3.SchemaObject) => {
+    const {format} = schema;
+
+    switch (format) {
+        case 'uuid':
+            return "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    }
+    return "string";
+}
+
+
+function generateNumberWithConstraints(schema: OpenAPIV3.SchemaObject) {
+    const {minimum, maximum, exclusiveMinimum, exclusiveMaximum} = schema;
+    const {multipleOf} = schema;
+    let defaultNumber = 0;
+    switch (schema.format) {
+        case 'int32':
+            defaultNumber = (2 ** 30) >>> 0;
+            break;
+        case 'int64':
+            defaultNumber = 2 ** 53 - 1;
+            break;
+        case 'float':
+        case 'double':
+            defaultNumber = 0.1;
+            break;
+    }
+
+    const epsilon = Number.isInteger(defaultNumber) ? 1 : Number.EPSILON;
+    let minValue = typeof minimum === "number" ? minimum : null;
+    let maxValue = typeof maximum === "number" ? maximum : null;
+    let constrainedNumber = defaultNumber;
+
+    if (typeof exclusiveMinimum === "number") {
+        minValue =
+            minValue !== null
+                ? Math.max(minValue, exclusiveMinimum + epsilon)
+                : exclusiveMinimum + epsilon;
+    }
+    if (typeof exclusiveMaximum === "number") {
+        maxValue =
+            maxValue !== null
+                ? Math.min(maxValue, exclusiveMaximum - epsilon)
+                : exclusiveMaximum - epsilon;
+    }
+    constrainedNumber =
+        (minValue as any > (maxValue as any) && defaultNumber) || minValue || maxValue || constrainedNumber;
+
+    if (typeof multipleOf === "number" && multipleOf > 0) {
+        const remainder = constrainedNumber % multipleOf;
+        constrainedNumber =
+            remainder === 0
+                ? constrainedNumber
+                : constrainedNumber + multipleOf - remainder;
+    }
+
+    return constrainedNumber;
 }
 
 export class SchemaExample {

--- a/src/openapi/SchemaExample.ts
+++ b/src/openapi/SchemaExample.ts
@@ -79,6 +79,9 @@ class SchemaExampleBuilder {
                     return []
                 case 'number':
                 case 'integer':
+                    if (schema.maximum || schema.minimum || schema.exclusiveMinimum || schema.exclusiveMaximum || schema.multipleOf) {
+                        return generateNumberWithConstraints(schema);
+                    }
                     return generateNumberWithConstraints(schema);
                 default: // null for OpenAPI 3.1
                     return null;

--- a/src/openapi/SchemaExample.ts
+++ b/src/openapi/SchemaExample.ts
@@ -22,39 +22,47 @@ class SchemaExampleBuilder {
                 this.visitedRefs.add(ref);
             }
         }
-        if ('oneOf' in schema) {
-            return this.build(schema.oneOf!![0], guessDefault);
-        }
+
         if (schema.example !== undefined) {
             return schema.example;
-        }
-        if ('allOf' in schema) {
-            const examples = schema.allOf!!.map((s) => this.build(s, true));
-            example = Object.assign({}, ...examples);
         }
 
         if (schema.default !== undefined) {
             return schema.default;
         }
+
+        if ('oneOf' in schema) {
+            return this.build(schema.oneOf!![0], guessDefault);
+        }
+
+        if ('allOf' in schema) {
+            const examples = schema.allOf!!.map((s) => this.build(s, true));
+            example = Object.assign({}, ...examples);
+        }
+
         if (schema.properties) {
             const obj: any = example ?? {};
             for (const key in schema.properties) {
-                obj[key] = this.build(schema.properties[key], true);
+               obj[key] = this.build(schema.properties[key], true);
             }
             example = obj;
         }
+
+        if (example) {
+            return example;
+        }
+
         if (schema.enum) {
             return schema.enum[0];
         }
+
         if ('items' in schema && schema.items) {
             if (schema.type === 'array' && schema.items && (schema.items as OpenAPIV3.SchemaObject).enum) {
                 return (schema.items as OpenAPIV3.SchemaObject).enum;
             }
             return [this.build(schema.items, true) ?? "string"];
         }
-        if (example) {
-            return example;
-        }
+
         // In 3.1 schema.type can be an array
         let type = (schema.type && typeof schema.type !== "string") ? schema.type[0] : schema.type;
         if (type && guessDefault) {

--- a/tests/jsonapi-openapi.spec.ts
+++ b/tests/jsonapi-openapi.spec.ts
@@ -1,0 +1,199 @@
+import {N8NPropertiesBuilder} from "../src/N8NPropertiesBuilder";
+import {INodeProperties} from "n8n-workflow";
+
+test('petstore.json', () => {
+    const doc = require('./samples/jsonapi-openapi.json');
+    const config = {}
+    const parser = new N8NPropertiesBuilder(doc, config);
+    const result = parser.build()
+
+    const expected: INodeProperties[] =  [
+        {
+            "displayName": "Resource",
+            "name": "resource",
+            "type": "options",
+            "noDataExpression": true,
+            "options": [
+                {
+                    "name": "Model",
+                    "value": "Model",
+                    "description": "Endpoints for the `Model` resource."
+                }
+            ],
+            "default": ""
+        },
+        {
+            "displayName": "Operation",
+            "name": "operation",
+            "type": "options",
+            "noDataExpression": true,
+            "displayOptions": {
+                "show": {
+                    "resource": [
+                        "Model"
+                    ]
+                }
+            },
+            "options": [
+                {
+                    "name": "Create Model",
+                    "value": "Create Model",
+                    "action": "Create a new model",
+                    "description": "Creates a new model resource with the provided data.",
+                    "routing": {
+                        "request": {
+                            "method": "POST",
+                            "url": "=/model/"
+                        }
+                    }
+                }
+            ],
+            "default": ""
+        },
+        {
+            "displayName": "POST /model/",
+            "name": "operation",
+            "type": "notice",
+            "typeOptions": {
+                "theme": "info"
+            },
+            "default": "",
+            "displayOptions": {
+                "show": {
+                    "resource": [
+                        "Model"
+                    ],
+                    "operation": [
+                        "Create Model"
+                    ]
+                }
+            }
+        },
+        {
+            "displayName": "Fields Model",
+            "name": "fields%5Bmodel%5D",
+            "description": "Specifies which fields should be returned.",
+            "default": [
+                "componentType", "count",
+                    "array",
+                    "modelType",
+                    "subModel",
+                    "view",
+                    "name"
+            ],
+            "type": "multiOptions",
+            "options": [
+                {
+                    "name": "Component Type",
+                    "value": "componentType"
+                },
+                {
+                    "name": "Count",
+                    "value": "count"
+                },
+                {
+                    "name": "Array",
+                    "value": "array"
+                },
+                {
+                    "name": "Model Type",
+                    "value": "modelType"
+                },
+                {
+                    "name": "Sub Model",
+                    "value": "subModel"
+                },
+                {
+                    "name": "View",
+                    "value": "view"
+                },
+                {
+                    "name": "Name",
+                    "value": "name"
+                }
+            ],
+            "routing": {
+                "send": {
+                    "type": "query",
+                    "property": "fields[model]",
+                    "value": "={{ $value.join(',') }}",
+                    "propertyInDotNotation": false
+                }
+            },
+            "displayOptions": {
+                "show": {
+                    "resource": [
+                        "Model"
+                    ],
+                    "operation": [
+                        "Create Model"
+                    ]
+                }
+            }
+        },
+        {
+            "displayName": "Include",
+            "name": "include",
+            "description": "Specifies which related resources should be returned.",
+            "default": [
+                "view", "subModel"
+            ],
+            "type": "multiOptions",
+            "options": [
+                {
+                    "name": "View",
+                    "value": "view"
+                },
+                {
+                    "name": "Sub Model",
+                    "value": "subModel"
+                }
+            ],
+            "routing": {
+                "send": {
+                    "type": "query",
+                    "property": "include",
+                    "value": "={{ $value.join(',') }}",
+                    "propertyInDotNotation": false
+                }
+            },
+            "displayOptions": {
+                "show": {
+                    "resource": [
+                        "Model"
+                    ],
+                    "operation": [
+                        "Create Model"
+                    ]
+                }
+            }
+        },
+        {
+            "required": true,
+            "displayName": "Data",
+            "name": "data",
+            "type": "json",
+            "default": "{\n  \"type\": \"model\",\n  \"attributes\": {\n    \"byteOffset\": 0,\n    \"componentType\": 0,\n    \"count\": 1073741824,\n    \"type\": \"TYPE_A\",\n    \"array\": [\n      \"string\"\n    ],\n    \"name\": \"string\"\n  },\n  \"relationships\": {\n    \"view\": null,\n    \"subModel\": null\n  }\n}",
+            "routing": {
+                "send": {
+                    "property": "data",
+                    "propertyInDotNotation": false,
+                    "type": "body",
+                    "value": "={{ JSON.parse($value) }}"
+                }
+            },
+            "displayOptions": {
+                "show": {
+                    "resource": [
+                        "Model"
+                    ],
+                    "operation": [
+                        "Create Model"
+                    ]
+                }
+            }
+        }
+    ]
+
+    expect(result).toEqual(expected);
+})

--- a/tests/jsonapi-openapi.spec.ts
+++ b/tests/jsonapi-openapi.spec.ts
@@ -42,6 +42,8 @@ test('petstore.json', () => {
                     "description": "Creates a new model resource with the provided data.",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "POST",
                             "url": "=/model/"
                         }

--- a/tests/petstore.spec.ts
+++ b/tests/petstore.spec.ts
@@ -51,6 +51,8 @@ test('petstore.json', () => {
                     "name": "Update Pet",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "PUT",
                             "url": "=/pet"
                         }
@@ -63,6 +65,8 @@ test('petstore.json', () => {
                     "name": "Add Pet",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "POST",
                             "url": "=/pet"
                         }
@@ -75,6 +79,8 @@ test('petstore.json', () => {
                     "name": "Find Pets By Status",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "GET",
                             "url": "=/pet/findByStatus"
                         }
@@ -87,6 +93,8 @@ test('petstore.json', () => {
                     "name": "Find Pets By Tags",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "GET",
                             "url": "=/pet/findByTags"
                         }
@@ -99,6 +107,8 @@ test('petstore.json', () => {
                     "name": "Get Pet By Id",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "GET",
                             "url": "=/pet/{{$parameter[\"petId\"]}}"
                         }
@@ -111,6 +121,8 @@ test('petstore.json', () => {
                     "name": "Update Pet With Form",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "POST",
                             "url": "=/pet/{{$parameter[\"petId\"]}}"
                         }
@@ -123,6 +135,8 @@ test('petstore.json', () => {
                     "name": "Delete Pet",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "DELETE",
                             "url": "=/pet/{{$parameter[\"petId\"]}}"
                         }
@@ -135,6 +149,8 @@ test('petstore.json', () => {
                     "name": "Upload File",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "POST",
                             "url": "=/pet/{{$parameter[\"petId\"]}}/uploadImage"
                         }
@@ -163,6 +179,8 @@ test('petstore.json', () => {
                     "name": "Get Inventory",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "GET",
                             "url": "=/store/inventory"
                         }
@@ -175,6 +193,8 @@ test('petstore.json', () => {
                     "name": "Place Order",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "POST",
                             "url": "=/store/order"
                         }
@@ -187,6 +207,8 @@ test('petstore.json', () => {
                     "name": "Get Order By Id",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "GET",
                             "url": "=/store/order/{{$parameter[\"orderId\"]}}"
                         }
@@ -199,6 +221,8 @@ test('petstore.json', () => {
                     "name": "Delete Order",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "DELETE",
                             "url": "=/store/order/{{$parameter[\"orderId\"]}}"
                         }
@@ -227,6 +251,8 @@ test('petstore.json', () => {
                     "name": "Create User",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "POST",
                             "url": "=/user"
                         }
@@ -239,6 +265,8 @@ test('petstore.json', () => {
                     "name": "Create Users With List Input",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "POST",
                             "url": "=/user/createWithList"
                         }
@@ -251,6 +279,8 @@ test('petstore.json', () => {
                     "name": "Login User",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "GET",
                             "url": "=/user/login"
                         }
@@ -263,6 +293,8 @@ test('petstore.json', () => {
                     "name": "Logout User",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "GET",
                             "url": "=/user/logout"
                         }
@@ -275,6 +307,8 @@ test('petstore.json', () => {
                     "name": "Get User By Name",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "GET",
                             "url": "=/user/{{$parameter[\"username\"]}}"
                         }
@@ -287,6 +321,8 @@ test('petstore.json', () => {
                     "name": "Update User",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "PUT",
                             "url": "=/user/{{$parameter[\"username\"]}}"
                         }
@@ -299,6 +335,8 @@ test('petstore.json', () => {
                     "name": "Delete User",
                     "routing": {
                         "request": {
+                            "encoding": "json",
+                            "json": true,
                             "method": "DELETE",
                             "url": "=/user/{{$parameter[\"username\"]}}"
                         }

--- a/tests/petstore.spec.ts
+++ b/tests/petstore.spec.ts
@@ -426,7 +426,7 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  {\n    \"id\": 0,\n    \"name\": \"string\"\n  }\n]",
+            "default": "[\n  {\n    \"id\": 9007199254740991,\n    \"name\": \"string\"\n  }\n]",
             "displayName": "Tags",
             "displayOptions": {
                 "show": {
@@ -606,7 +606,7 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  {\n    \"id\": 0,\n    \"name\": \"string\"\n  }\n]",
+            "default": "[\n  {\n    \"id\": 9007199254740991,\n    \"name\": \"string\"\n  }\n]",
             "displayName": "Tags",
             "displayOptions": {
                 "show": {

--- a/tests/petstore.spec.ts
+++ b/tests/petstore.spec.ts
@@ -401,7 +401,7 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  null\n]",
+            "default": "[\n  \"string\"\n]",
             "displayName": "Photo Urls",
             "displayOptions": {
                 "show": {
@@ -426,7 +426,7 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  {}\n]",
+            "default": "[\n  {\n    \"id\": 0,\n    \"name\": \"string\"\n  }\n]",
             "displayName": "Tags",
             "displayOptions": {
                 "show": {
@@ -581,7 +581,7 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  null\n]",
+            "default": "[\n  \"string\"\n]",
             "displayName": "Photo Urls",
             "displayOptions": {
                 "show": {
@@ -606,7 +606,7 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  {}\n]",
+            "default": "[\n  {\n    \"id\": 0,\n    \"name\": \"string\"\n  }\n]",
             "displayName": "Tags",
             "displayOptions": {
                 "show": {
@@ -746,7 +746,7 @@ test('petstore.json', () => {
             }
         },
         {
-            "default": "[\n  null\n]",
+            "default": "[\n  \"string\"\n]",
             "description": "Tags to filter by",
             "displayName": "Tags",
             "displayOptions": {

--- a/tests/samples/jsonapi-openapi.json
+++ b/tests/samples/jsonapi-openapi.json
@@ -1,0 +1,734 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Example of a JSON API in a OpenAPI format",
+    "description": "My json api example",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/model/": {
+      "post": {
+        "tags": [
+          "Model"
+        ],
+        "summary": "Create a new model",
+        "description": "Creates a new model resource with the provided data.",
+        "operationId": "create_model",
+        "parameters": [
+          {
+            "name": "fields[model]",
+            "in": "query",
+            "description": "Specifies which fields should be returned.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "componentType",
+                  "count",
+                  "array",
+                  "modelType",
+                  "subModel",
+                  "view",
+                  "name"
+                ]
+              }
+            },
+            "explode": false
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Specifies which related resources should be returned.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "view",
+                  "subModel"
+                ]
+              }
+            },
+            "explode": false
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModelResourceCreationRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "included",
+                    "links"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ModelResourceObject"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ModelResourceRelationshipValue"
+                      }
+                    },
+                    "links": {
+                      "type": "object",
+                      "required": [
+                        "self"
+                      ],
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "default": "/model"
+                        },
+                        "first": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "default": "/model?page[number]=1&page[size]=10"
+                        },
+                        "last": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "default": "/model?page[number]=10&page[size]=10"
+                        },
+                        "prev": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "default": "/model?page[number]=2&page[size]=10"
+                        },
+                        "next": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "default": "/model?page[number]=4&page[size]=10"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "errors"
+                      ],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "status",
+                              "title",
+                              "detail"
+                            ],
+                            "properties": {
+                              "status": {
+                                "type": "string",
+                                "example": "404"
+                              },
+                              "title": {
+                                "type": "string",
+                                "example": "Not found"
+                              },
+                              "detail": {
+                                "type": "string",
+                                "example": "The requested resource cannot be found."
+                              },
+                              "source": {
+                                "oneOf": [
+                                  {
+                                    "type": "null"
+                                  },
+                                  {
+                                    "$ref": "#/components/schemas/Source"
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "example": "\n{\n  \"errors\": [\n    {\n      \"status\": \"404\",\n      \"title\": \"Resource not found\",\n      \"detail\": \"The requested resource could not be found.\"\n    }\n  ]\n}\n"
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "errors"
+                      ],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "status",
+                              "title",
+                              "detail"
+                            ],
+                            "properties": {
+                              "status": {
+                                "type": "string",
+                                "example": "404"
+                              },
+                              "title": {
+                                "type": "string",
+                                "example": "Not found"
+                              },
+                              "detail": {
+                                "type": "string",
+                                "example": "The requested resource cannot be found."
+                              },
+                              "source": {
+                                "oneOf": [
+                                  {
+                                    "type": "null"
+                                  },
+                                  {
+                                    "$ref": "#/components/schemas/Source"
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "example": "\n{\n  \"errors\": [\n    {\n      \"status\": \"500\",\n      \"title\": \"Internal server error\",\n      \"detail\": \"The server has encountered a situation it does not know how to handle.\"\n    }\n  ]\n}\n"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ModelComponentType": {
+        "type": "integer",
+        "description": "The datatype of the model’s components.",
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          5,
+          6
+        ],
+        "example": 0
+      },
+      "ModelResourceCreationAttributes": {
+        "type": "object",
+        "required": [
+          "componentType",
+          "count",
+          "type"
+        ],
+        "properties": {
+          "byteOffset": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "An offset.",
+            "default": 0,
+            "minimum": 0
+          },
+          "componentType": {
+            "$ref": "#/components/schemas/ModelComponentType",
+            "description": "The datatype of the model’s components."
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32",
+            "description": "A count.",
+            "minimum": 1
+          },
+          "type": {
+            "$ref": "#/components/schemas/ModelType",
+            "description": "Specifies the model’s type."
+          },
+          "array": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {},
+            "description": "An array."
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "A name."
+          }
+        }
+      },
+      "ModelResourceCreationPayload": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "default": "model"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "attributes"
+            ],
+            "properties": {
+              "attributes": {
+                "$ref": "#/components/schemas/ModelResourceCreationAttributes"
+              },
+              "relationships": {
+                "$ref": "#/components/schemas/ModelResourceCreationRelationships"
+              }
+            }
+          }
+        ]
+      },
+      "ModelResourceCreationRelationships": {
+        "type": "object",
+        "properties": {
+          "view": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ViewResourceRelationshipToOne"
+              }
+            ]
+          },
+          "subModel": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SubModelResourceRelationshipToOne"
+              }
+            ]
+          }
+        }
+      },
+      "ModelResourceCreationRequestBody": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ModelResourceCreationPayload"
+          }
+        }
+      },
+      "ModelResourceIdentifierObject": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "default": "model"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ]
+      },
+      "ModelResourceObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ModelResourceIdentifierObject"
+          },
+          {
+            "type": "object",
+            "required": [
+              "attributes",
+              "relationships"
+            ],
+            "properties": {
+              "attributes": {
+                "$ref": "#/components/schemas/SubModelResourceAttributesObject"
+              },
+              "relationships": {
+                "$ref": "#/components/schemas/SubModelResourceRelationshipsObject"
+              }
+            }
+          }
+        ],
+        "description": "Some model included in the original model."
+      },
+      "ModelResourceRelationshipValue": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SubModelResourceObject"
+          },
+          {
+            "$ref": "#/components/schemas/ViewResourceObject"
+          }
+        ]
+      },
+      "SubModelResourceAttributesObject": {
+        "type": "object",
+        "properties": {
+          "byteOffset": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "The offset.",
+            "default": 0,
+            "minimum": 0
+          },
+          "componentType": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ModelComponentType",
+                "description": "The datatype of the model."
+              }
+            ]
+          },
+          "count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "A number.",
+            "minimum": 1
+          },
+          "type": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ModelType",
+                "description": "The model’s type."
+              }
+            ]
+          },
+          "array": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {},
+            "description": "An array."
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "A name."
+          }
+        }
+      },
+      "SubModelResourceRelationshipsObject": {
+        "type": "object",
+        "properties": {
+          "view": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ViewResourceRelationshipToOne"
+              }
+            ]
+          },
+          "subModel": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SubModelResourceRelationshipToOne"
+              }
+            ]
+          }
+        }
+      },
+      "SubModelResourceIdentifierObject": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "default": "model-subModel"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ]
+      },
+      "SubModelResourceObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SubModelResourceIdentifierObject"
+          },
+          {
+            "type": "object",
+            "required": [
+              "attributes",
+              "relationships"
+            ],
+            "properties": {
+              "attributes": {
+                "$ref": "#/components/schemas/SubSubModelResourceAttributesObject"
+              },
+              "relationships": {
+                "$ref": "#/components/schemas/SubSubModelResourceRelationshipsObject"
+              }
+            }
+          }
+        ],
+        "description": "Some submodel."
+      },
+      "SubModelResourceRelationshipToOne": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SubModelResourceIdentifierObject"
+          }
+        }
+      },
+      "SubSubModelResourceAttributesObject": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "A number.",
+            "minimum": 0
+          }
+        }
+      },
+      "SubSubModelResourceRelationshipsObject": {
+        "type": "object",
+        "properties": {
+          "values": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SubModelValuesResourceRelationshipToOne"
+              }
+            ]
+          }
+        }
+      },
+      "SubModelValuesResourceIdentifierObject": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "default": "model-sub-model-values"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ]
+      },
+      "SubModelValuesResourceRelationshipToOne": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SubModelValuesResourceIdentifierObject"
+          }
+        }
+      },
+      "ModelType": {
+        "type": "string",
+        "description": "Set a model type",
+        "enum": [
+          "TYPE_A",
+          "TYPE_B",
+          "TYPE_C"
+        ]
+      },
+      "ViewResourceIdentifierObject": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "default": "view"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ]
+      },
+      "ViewResourceObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ViewResourceIdentifierObject"
+          }
+        ],
+        "description": "A view."
+      },
+      "ViewResourceRelationshipToOne": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ViewResourceIdentifierObject"
+          }
+        }
+      },
+      "Source": {
+        "type": "object",
+        "required": [
+          "pointer"
+        ],
+        "properties": {
+          "pointer": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Model",
+      "description": "Endpoints for the `Model` resource."
+    }
+  ]
+}


### PR DESCRIPTION
Hello,

We are using n8n-openapi-node with a JSON-API and we like your library very much, but we have complex types, so we needed to fix some bugs, like:
- query parameters like `fields[model]` that were not handled correctly
- issues in the example recursivity
- add a multi-option when having an array of enums

We also set the JSON examples to resemble those Swagger generates (some defaults are missing).

Here are the fixes. We don't know what you envision for your library, so tell us if you don't want to have everything.