### PR TITLE
Encode name as URI for the query parameter

### DIFF
--- a/src/n8n/SchemaToINodeProperties.ts
+++ b/src/n8n/SchemaToINodeProperties.ts
@@ -102,7 +102,7 @@ export class N8NINodeProperties {
         }
         const fieldParameterKeys: Partial<INodeProperties> = {
             displayName: lodash.startCase(parameter.name),
-            name: parameter.name.replace(/\./g, "-"),
+            name: encodeURIComponent(parameter.name.replace(/\./g, "-")),
             required: parameter.required,
             description: parameter.description,
             default: parameter.example,


### PR DESCRIPTION
## Description

The goal of this MR is close to https://github.com/devlikeapro/n8n-openapi-node/commit/e4548c969ec30d65df0cc6f4156284d1535ca7a2 but more inclusive. For instance, currently, if your query parameter is `fields[model]`, the parameter changed in n8n won't be used in the actual query, and the default values will be used.

## Effects in n8n UI

None

## Side effects

I don't see any for those who aren't concerned, as it will leave their variable the same.