### PR TITLE
feat: add support for content types ending in +json

### DIFF
--- a/src/N8NPropertiesBuilder.spec.ts
+++ b/src/N8NPropertiesBuilder.spec.ts
@@ -146,7 +146,13 @@ test('query param - schema', () => {
     ]);
 });
 
-test('query param - content', () => {
+const contentTypes = [
+    ['application/json'],
+    ['application/openapi+json'],
+    ['application/vnd.api+json'],
+];
+
+test.each(contentTypes)('query param - content', (contentType) => {
     const paths = {
         '/api/entities': {
             get: {
@@ -160,7 +166,7 @@ test('query param - content', () => {
                         example: false,
                         description: 'Filter description',
                         content: {
-                            'application/json': {
+                            [contentType]: {
                                 schema: {
                                     $ref: '#/components/schemas/Entity',
                                 },
@@ -501,7 +507,7 @@ test('path param', () => {
     ]);
 });
 
-test('request body', () => {
+test.each(contentTypes)('request body', (contentType) => {
     const paths = {
         '/api/entities': {
             post: {
@@ -509,7 +515,7 @@ test('request body', () => {
                 summary: 'Create entity',
                 requestBody: {
                     content: {
-                        'application/json': {
+                        [contentType]: {
                             schema: {
                                 $ref: '#/components/schemas/Entity',
                             },

--- a/src/n8n/SchemaToINodeProperties.ts
+++ b/src/n8n/SchemaToINodeProperties.ts
@@ -93,7 +93,7 @@ export class N8NINodeProperties {
             fieldSchemaKeys = this.fromSchema(parameter.schema!!);
         }
         if (!fieldSchemaKeys) {
-            const regexp = /application\/json.*/
+            const regexp = /application\/(?:.*\+)?json.*/
             const content = findKey(parameter.content, regexp)
             fieldSchemaKeys = this.fromSchema(content.schema);
         }
@@ -168,7 +168,7 @@ export class N8NINodeProperties {
             return [];
         }
         body = this.refResolver.resolve<OpenAPIV3.RequestBodyObject>(body)
-        const regexp = /application\/json.*/
+        const regexp = /application\/(?:.*\+)?json.*/
         const content = findKey(body.content, regexp)
         if (!content) {
             throw new Error(`No '${regexp}' content found`);


### PR DESCRIPTION
Currently only `application/json` works as a content type. I expanded the regex to allow `application/{anything}+json`.